### PR TITLE
Implement Bitmap Transformation with Size Limit

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -61,11 +61,6 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         view.setSource(source);
     }
 
-    @ReactProp(name = "disableTransformation")
-    public void setDisableTransformation(FastImageViewWithUrl view, @Nullable Boolean disableTransformation) {
-        view.disableTransformation(disableTransformation);
-    }
-
     @ReactProp(name = "defaultSource")
     public void setDefaultSource(FastImageViewWithUrl view, @Nullable String source) {
         view.setDefaultSource(

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -39,7 +39,6 @@ class FastImageViewWithUrl extends AppCompatImageView {
     private boolean mNeedsReload = false;
     private ReadableMap mSource = null;
     private Drawable mDefaultSource = null;
-    private boolean mDisableTransformation = false;
 
     public GlideUrl glideUrl;
 
@@ -50,11 +49,6 @@ class FastImageViewWithUrl extends AppCompatImageView {
     public void setSource(@Nullable ReadableMap source) {
         mNeedsReload = true;
         mSource = source;
-    }
-
-    public void disableTransformation(@Nullable boolean disableTransform) {
-        mNeedsReload = true;
-        mDisableTransformation = disableTransform;
     }
 
     public void setDefaultSource(@Nullable Drawable source) {
@@ -182,11 +176,8 @@ class FastImageViewWithUrl extends AppCompatImageView {
                             .apply(FastImageViewConverter
                                     .getOptions(context, imageSource, mSource)
                                     .placeholder(mDefaultSource) // show until loaded
-                                    .fallback(mDefaultSource)); // null will not be treated as error
-
-            if (mDisableTransformation) {
-                builder = builder.dontTransform();
-            }
+                                    .fallback(mDefaultSource))
+                            .transform(new ResizeTransformation());
 
             if (key != null)
                 builder.listener(new FastImageRequestListener(key));

--- a/android/src/main/java/com/dylanvann/fastimage/ResizeTransformation.java
+++ b/android/src/main/java/com/dylanvann/fastimage/ResizeTransformation.java
@@ -1,0 +1,41 @@
+package com.dylanvann.fastimage;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import androidx.annotation.NonNull;
+
+import com.bumptech.glide.load.Transformation;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.resource.bitmap.BitmapResource;
+
+import java.security.MessageDigest;
+
+public class ResizeTransformation implements Transformation<Bitmap> {
+
+    private final double MAX_BYTES = 25000000.0;
+
+    @NonNull
+    @Override
+    public Resource<Bitmap> transform(@NonNull Context context, @NonNull Resource<Bitmap> resource, int outWidth, int outHeight) {
+        Bitmap toTransform = resource.get();
+
+        if (toTransform.getByteCount() > MAX_BYTES) {
+            double scaleFactor = Math.sqrt(MAX_BYTES / (double) toTransform.getByteCount());
+            int newHeight = (int) (outHeight * scaleFactor);
+            int newWidth = (int) (outWidth * scaleFactor);
+
+            BitmapPool pool = GlideApp.get(context).getBitmapPool();
+            Bitmap scaledBitmap =  Bitmap.createScaledBitmap(toTransform, newWidth, newHeight, true);
+            return BitmapResource.obtain(scaledBitmap, pool);
+        }
+
+        return resource;
+    }
+
+    @Override
+    public void updateDiskCacheKey(@NonNull MessageDigest messageDigest) {
+        messageDigest.update(("ResizeTransformation").getBytes());
+    }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,20 +1,20 @@
 import React, { forwardRef, memo } from 'react'
 import {
-    View,
-    Image,
-    NativeModules,
-    requireNativeComponent,
-    StyleSheet,
+    AccessibilityProps,
+    ColorValue,
     FlexStyle,
+    Image,
+    ImageRequireSource,
     LayoutChangeEvent,
+    NativeModules,
+    Platform,
     ShadowStyleIOS,
     StyleProp,
+    StyleSheet,
     TransformsStyle,
-    ImageRequireSource,
-    Platform,
-    AccessibilityProps,
+    View,
     ViewProps,
-    ColorValue,
+    requireNativeComponent,
 } from 'react-native'
 
 export type ResizeMode = 'contain' | 'cover' | 'stretch' | 'center'
@@ -54,8 +54,8 @@ export type Source = {
 
 export interface OnLoadStartEvent {
     nativeEvent: {
-        cachePath: string | null;
-    };
+        cachePath: string | null
+    }
 }
 
 export interface OnLoadEvent {
@@ -123,13 +123,6 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
      * If supplied, changes the color of all the non-transparent pixels to the given color.
      */
     tintColor?: ColorValue
-
-    /**
-     * If supplied, the original size of the resource without any transformations will be displayed.
-     * 
-     * @platform android
-     */
-    disableTransformation?: boolean
 
     /**
      * A unique identifier for this element to be used in UI Automation testing scripts.


### PR DESCRIPTION
This pull request introduces a new transformation method for handling Bitmap objects with a size limit. It provides an implementation that scales down the input Bitmap if its byte count exceeds the specified threshold.

This pull request addresses an issue encountered when dealing with large images on Android devices with hardware acceleration enabled. The issue manifests as a `java.lang.RuntimeException: Canvas: trying to draw too large(xxx,xxx,xxx bytes) bitmap` error. By introducing a new transformation method, this pull request offers a solution to display large images while still accommodating the specified size limit.

Changes Made:

Added a new class ResizeTransformation, transform, to perform the Bitmap transformation.
The transform method uses a BitmapPool, the transform Bitmap, and output width and height as parameters.
If the transform Bitmap's byte count exceeds the predefined MAX_BYTES threshold:
A scaling factor is calculated based on the square root of the ratio between MAX_BYTES and the transform Bitmap's byte count.
The new width and height are computed by multiplying the output width and height by the scaling factor.
The Bitmap.createScaledBitmap() method creates a scaled Bitmap with new dimensions.
The scaled Bitmap is returned as the result of the transformation.
If the transform Bitmap's byte count is within the MAX_BYTES threshold:
The original toTransform Bitmap is returned as it is.

Overall, this pull request aims to provide a reusable and efficient Bitmap transformation implementation that handles size limitations, allowing for optimized memory usage when working with large images.

Related issues:
https://github.com/Expensify/App/issues/17427
https://github.com/Expensify/App/issues/18963
https://github.com/Expensify/App/issues/24337